### PR TITLE
refactor: remove dependency from tab samples

### DIFF
--- a/bot-sso-docker/infra/azure.bicep
+++ b/bot-sso-docker/infra/azure.bicep
@@ -147,5 +147,5 @@ output AZURE_CONTAINER_REGISTRY_SERVER string = acr.outputs.loginServer
 output AZURE_CONTAINER_APP_NAME string = containerApp.name
 output BOT_DOMAIN string = containerApp.properties.configuration.ingress.fqdn
 output AZURE_CONTAINER_APP_RESOURCE_ID string = containerApp.id
-output clientId string = identity.properties.clientId
-output tenantId string = identity.properties.tenantId
+output BOT_ID string = identity.properties.clientId
+output BOT_TENANT_ID string = identity.properties.tenantId

--- a/bot-sso-docker/m365agents.yml
+++ b/bot-sso-docker/m365agents.yml
@@ -93,8 +93,8 @@ deploy:
     name: deploy container image
     with:
       run: az containerapp up -n ${{AZURE_CONTAINER_APP_NAME}} --image
-        ${{AZURE_CONTAINER_IMAGE}} --env-vars "BOT_ID=secretref:bot-id"
-        "BOT_TENANT_ID=secretref:bot-tenant-id" "BOT_TYPE=secretref:bot-type" "BOT_DOMAIN=${{BOT_DOMAIN}}"
+        ${{AZURE_CONTAINER_IMAGE}} --env-vars "clientId=secretref:bot-id"
+        "tenantId=secretref:bot-tenant-id" "BOT_TYPE=secretref:bot-type" "BOT_DOMAIN=${{BOT_DOMAIN}}"
         "AAD_APP_CLIENT_ID=secretref:aad-app-client-id"
         "AAD_APP_CLIENT_SECRET=secretref:aad-app-client-secret"
         "AAD_APP_TENANT_ID=secretref:aad-app-tenant-id"

--- a/hello-world-bot-with-tab/tab/package.json
+++ b/hello-world-bot-with-tab/tab/package.json
@@ -8,8 +8,6 @@
   "dependencies": {
     "@fluentui/react-components": "^9.55.1",
     "@microsoft/teams-js": "^2.22.0",
-    "@microsoft/teamsfx": "^3.0.0-alpha",
-    "@microsoft/teamsfx-react": "^4.0.0-alpha",
     "axios": "^1.6.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/hello-world-bot-with-tab/tab/src/components/App.tsx
+++ b/hello-world-bot-with-tab/tab/src/components/App.tsx
@@ -5,7 +5,7 @@ import { HashRouter as Router, Navigate, Route, Routes } from "react-router-dom"
 import Privacy from "./Privacy";
 import TermsOfUse from "./TermsOfUse";
 import Tab from "./Tab";
-import { useTeams } from "@microsoft/teamsfx-react";
+import { useTeams } from "./useTeams";
 import { app } from "@microsoft/teams-js";
 
 /**

--- a/hello-world-bot-with-tab/tab/src/components/useTeams.tsx
+++ b/hello-world-bot-with-tab/tab/src/components/useTeams.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from "react";
+import { unstable_batchedUpdates as batchedUpdates } from "react-dom";
+import { app, pages } from "@microsoft/teams-js";
+import {
+  teamsLightTheme,
+  teamsDarkTheme,
+  teamsHighContrastTheme,
+} from "@fluentui/react-components";
+
+const getTheme = () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const theme = urlParams.get("theme");
+  return theme == null ? undefined : theme;
+};
+
+/**
+ * Microsoft Teams React hook
+ * @param {Object} options optional options
+ * @returns A tuple with properties and methods
+ * properties:
+ *  - inTeams: boolean = true if inside Microsoft Teams
+ *  - fullscreen: boolean = true if in full screen mode
+ *  - theme: Fluent UI Theme
+ *  - themeString: string - representation of the theme (default, dark or contrast)
+ *  - context - the Microsoft Teams JS SDK context
+ * methods:
+ *  - setTheme - manually set the theme
+ */
+export function useTeams(options) {
+  const [loading, setLoading] = useState(undefined);
+  const [inTeams, setInTeams] = useState(undefined);
+  const [fullScreen, setFullScreen] = useState(undefined);
+  const [theme, setTheme] = useState(teamsLightTheme);
+  const [themeString, setThemeString] = useState("default");
+  const [initialTheme] = useState(
+    options && options.initialTheme ? options.initialTheme : getTheme()
+  );
+  const [context, setContext] = useState(undefined);
+
+  const themeChangeHandler = (theme) => {
+    setThemeString(theme || "default");
+    switch (theme) {
+      case "dark":
+        setTheme(teamsDarkTheme);
+        break;
+      case "contrast":
+        setTheme(teamsHighContrastTheme);
+        break;
+      case "default":
+      default:
+        setTheme(teamsLightTheme);
+    }
+  };
+
+  const overrideThemeHandler = options?.setThemeHandler
+    ? options.setThemeHandler
+    : themeChangeHandler;
+
+  useEffect(() => {
+    // set initial theme based on options or query string
+    if (initialTheme) {
+      overrideThemeHandler(initialTheme);
+    }
+
+    app
+      .initialize()
+      .then(() => {
+        app
+          .getContext()
+          .then((context) => {
+            batchedUpdates(() => {
+              setInTeams(true);
+              setContext(context);
+              setFullScreen(context.page.isFullScreen);
+            });
+            overrideThemeHandler(context.app.theme);
+            app.registerOnThemeChangeHandler(overrideThemeHandler);
+            pages.registerFullScreenHandler((isFullScreen) => {
+              setFullScreen(isFullScreen);
+            });
+            setLoading(false);
+          })
+          .catch(() => {
+            setLoading(false);
+            setInTeams(false);
+          });
+      })
+      .catch(() => {
+        setLoading(false);
+        setInTeams(false);
+      });
+  }, [initialTheme, overrideThemeHandler]);
+
+  return [
+    {
+      inTeams,
+      fullScreen,
+      theme,
+      themeString,
+      context,
+      loading,
+    },
+    {
+      setTheme: (theme) => {
+        overrideThemeHandler(theme);
+      },
+    },
+  ];
+}

--- a/hello-world-in-meeting/package.json
+++ b/hello-world-in-meeting/package.json
@@ -8,8 +8,6 @@
   "dependencies": {
     "@fluentui/react-components": "^9.18.0",
     "@microsoft/teams-js": "^2.22.0",
-    "@microsoft/teamsfx": "^2.2.0",
-    "@microsoft/teamsfx-react": "^3.0.0",
     "axios": "^0.21.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/hello-world-tab-codespaces/package.json
+++ b/hello-world-tab-codespaces/package.json
@@ -8,8 +8,6 @@
   "dependencies": {
     "@fluentui/react-components": "^9.18.0",
     "@microsoft/teams-js": "^2.22.0",
-    "@microsoft/teamsfx": "^2.2.0",
-    "@microsoft/teamsfx-react": "^3.0.0",
     "axios": "^0.21.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/hello-world-tab-codespaces/src/components/App.jsx
+++ b/hello-world-tab-codespaces/src/components/App.jsx
@@ -15,7 +15,7 @@ import Privacy from "./Privacy";
 import TermsOfUse from "./TermsOfUse";
 import Tab from "./Tab";
 import TabConfig from "./TabConfig";
-import { useTeams } from "@microsoft/teamsfx-react";
+import { useTeams } from "./useTeams";
 
 /**
  * The main app which handles the initialization and routing

--- a/hello-world-tab-codespaces/src/components/useTeams.jsx
+++ b/hello-world-tab-codespaces/src/components/useTeams.jsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from "react";
+import { unstable_batchedUpdates as batchedUpdates } from "react-dom";
+import { app, pages } from "@microsoft/teams-js";
+import {
+  teamsLightTheme,
+  teamsDarkTheme,
+  teamsHighContrastTheme,
+} from "@fluentui/react-components";
+
+const getTheme = () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const theme = urlParams.get("theme");
+  return theme == null ? undefined : theme;
+};
+
+/**
+ * Microsoft Teams React hook
+ * @param {Object} options optional options
+ * @returns A tuple with properties and methods
+ * properties:
+ *  - inTeams: boolean = true if inside Microsoft Teams
+ *  - fullscreen: boolean = true if in full screen mode
+ *  - theme: Fluent UI Theme
+ *  - themeString: string - representation of the theme (default, dark or contrast)
+ *  - context - the Microsoft Teams JS SDK context
+ * methods:
+ *  - setTheme - manually set the theme
+ */
+export function useTeams(options) {
+  const [loading, setLoading] = useState(undefined);
+  const [inTeams, setInTeams] = useState(undefined);
+  const [fullScreen, setFullScreen] = useState(undefined);
+  const [theme, setTheme] = useState(teamsLightTheme);
+  const [themeString, setThemeString] = useState("default");
+  const [initialTheme] = useState(
+    options && options.initialTheme ? options.initialTheme : getTheme()
+  );
+  const [context, setContext] = useState(undefined);
+
+  const themeChangeHandler = (theme) => {
+    setThemeString(theme || "default");
+    switch (theme) {
+      case "dark":
+        setTheme(teamsDarkTheme);
+        break;
+      case "contrast":
+        setTheme(teamsHighContrastTheme);
+        break;
+      case "default":
+      default:
+        setTheme(teamsLightTheme);
+    }
+  };
+
+  const overrideThemeHandler = options?.setThemeHandler
+    ? options.setThemeHandler
+    : themeChangeHandler;
+
+  useEffect(() => {
+    // set initial theme based on options or query string
+    if (initialTheme) {
+      overrideThemeHandler(initialTheme);
+    }
+
+    app
+      .initialize()
+      .then(() => {
+        app
+          .getContext()
+          .then((context) => {
+            batchedUpdates(() => {
+              setInTeams(true);
+              setContext(context);
+              setFullScreen(context.page.isFullScreen);
+            });
+            overrideThemeHandler(context.app.theme);
+            app.registerOnThemeChangeHandler(overrideThemeHandler);
+            pages.registerFullScreenHandler((isFullScreen) => {
+              setFullScreen(isFullScreen);
+            });
+            setLoading(false);
+          })
+          .catch(() => {
+            setLoading(false);
+            setInTeams(false);
+          });
+      })
+      .catch(() => {
+        setLoading(false);
+        setInTeams(false);
+      });
+  }, [initialTheme, overrideThemeHandler]);
+
+  return [
+    {
+      inTeams,
+      fullScreen,
+      theme,
+      themeString,
+      context,
+      loading,
+    },
+    {
+      setTheme: (theme) => {
+        overrideThemeHandler(theme);
+      },
+    },
+  ];
+}

--- a/hello-world-tab-docker/api/package.json
+++ b/hello-world-tab-docker/api/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "@azure/functions": "^4.1.0",
-    "@microsoft/teamsfx": "^2.0.0",
+    "@azure/identity": "^4.4.1",
+    "jwt-decode": "^4.0.0",
     "@microsoft/microsoft-graph-client": "^3.0.5",
     "isomorphic-fetch": "^3.0.0"
   },

--- a/hello-world-tab-docker/package.json
+++ b/hello-world-tab-docker/package.json
@@ -2,14 +2,13 @@
   "name": "teamsfx-template-tab",
   "version": "0.1.0",
   "engines": {
-    "node": "16 || 18"
+    "node": "18 || 20 || 22"
   },
   "private": true,
   "dependencies": {
     "@fluentui/react-components": "^9.18.0",
     "@microsoft/teams-js": "^2.22.0",
-    "@microsoft/teamsfx": "^2.2.0",
-    "@microsoft/teamsfx-react": "^3.0.0",
+    "@azure/msal-browser": "^4.12.0",
     "axios": "^0.21.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/hello-world-tab-docker/src/components/App.tsx
+++ b/hello-world-tab-docker/src/components/App.tsx
@@ -9,21 +9,17 @@ import {
 import { useEffect } from "react";
 import { HashRouter as Router, Navigate, Route, Routes } from "react-router-dom";
 import { app } from "@microsoft/teams-js";
-import { useTeamsUserCredential } from "@microsoft/teamsfx-react";
 import Tab from "./Tab";
 import TabConfig from "./TabConfig";
 import { TeamsFxContext } from "./Context";
-import config from "./sample/lib/config";
+import { useTeams } from "./sample/lib/useTeams";
 
 /**
  * The main app which handles the initialization and routing
  * of the app.
  */
 export default function App() {
-  const { loading, theme, themeString, teamsUserCredential } = useTeamsUserCredential({
-    initiateLoginEndpoint: config.initiateLoginEndpoint!,
-    clientId: config.clientId!,
-  });
+  const [{ loading, themeString, theme }] = useTeams();
   useEffect(() => {
     loading &&
       app.initialize().then(() => {
@@ -32,7 +28,7 @@ export default function App() {
       });
   }, [loading]);
   return (
-    <TeamsFxContext.Provider value={{ theme, themeString, teamsUserCredential }}>
+    <TeamsFxContext.Provider value={{ theme, themeString }}>
       <FluentProvider
         theme={
           themeString === "dark"

--- a/hello-world-tab-docker/src/components/Context.tsx
+++ b/hello-world-tab-docker/src/components/Context.tsx
@@ -1,13 +1,10 @@
-import { TeamsUserCredential } from "@microsoft/teamsfx";
 import { createContext } from "react";
 import { Theme } from "@fluentui/react-components";
 
 export const TeamsFxContext = createContext<{
   theme?: Theme;
   themeString: string;
-  teamsUserCredential?: TeamsUserCredential;
 }>({
   theme: undefined,
   themeString: "",
-  teamsUserCredential: undefined,
 });

--- a/hello-world-tab-docker/src/components/sample/Welcome.tsx
+++ b/hello-world-tab-docker/src/components/sample/Welcome.tsx
@@ -1,4 +1,5 @@
-import { useContext, useState } from "react";
+import { useState } from "react";
+import { app } from "@microsoft/teams-js";
 import {
   Image,
   TabList,
@@ -11,10 +12,9 @@ import "./Welcome.css";
 import { EditCode } from "./EditCode";
 import { AzureFunctions } from "./AzureFunctions";
 import { CurrentUser } from "./CurrentUser";
-import { useData } from "@microsoft/teamsfx-react";
+import { useData } from "./lib/useData";
 import { Deploy } from "./Deploy";
 import { Publish } from "./Publish";
-import { TeamsFxContext } from "../Context";
 
 export function Welcome(props: { showFunction?: boolean; environment?: string }) {
   const { showFunction, environment } = {
@@ -33,11 +33,13 @@ export function Welcome(props: { showFunction?: boolean; environment?: string })
   const onTabSelect = (event: SelectTabEvent, data: SelectTabData) => {
     setSelectedValue(data.value);
   };
-  const { teamsUserCredential } = useContext(TeamsFxContext);
   const { loading, data, error } = useData(async () => {
-    if (teamsUserCredential) {
-      const userInfo = await teamsUserCredential.getUserInfo();
-      return userInfo;
+    await app.initialize();
+    const context = await app.getContext();
+    if (context.user) {
+      return {
+        displayName: context.user.displayName || "",
+      };
     }
   });
   const userName = loading || error ? "" : data!.displayName;

--- a/hello-world-tab-docker/src/components/sample/lib/config.ts
+++ b/hello-world-tab-docker/src/components/sample/lib/config.ts
@@ -1,6 +1,7 @@
 const config = {
   initiateLoginEndpoint: process.env.REACT_APP_START_LOGIN_PAGE_URL,
   clientId: process.env.REACT_APP_CLIENT_ID,
+  tenantId: process.env.TEAMS_APP_TENANT_ID,
   apiEndpoint: process.env.REACT_APP_FUNC_ENDPOINT,
   apiName: process.env.REACT_APP_FUNC_NAME,
 };

--- a/hello-world-tab-docker/src/components/sample/lib/useData.ts
+++ b/hello-world-tab-docker/src/components/sample/lib/useData.ts
@@ -1,0 +1,70 @@
+import { useEffect, useReducer } from "react";
+
+type State<T> = {
+  /**
+   * User data.
+   */
+  data?: T;
+  /**
+   * Status of data loading.
+   */
+  loading: boolean;
+  /**
+   * Error information.
+   */
+  error?: unknown;
+};
+
+type Action<T> =
+  | { type: "loading" }
+  | { type: "result"; result: T }
+  | { type: "error"; error: unknown };
+
+export type Data<T> = State<T> & {
+  /**
+   * reload function.
+   */
+  reload: () => void;
+};
+
+const createReducer =
+  <T>() =>
+  (state: State<T>, action: Action<T>): State<T> => {
+    switch (action.type) {
+      case "loading":
+        return { data: state.data, loading: true };
+      case "result":
+        return { data: action.result, loading: false };
+      case "error":
+        return { loading: false, error: action.error };
+    }
+  };
+
+/**
+ * Helper function to fetch data with status and error.
+ *
+ * @param fetchDataAsync - async function of how to fetch data
+ * @param options - if autoLoad is true, reload data immediately
+ * @returns data, loading status, error and reload function
+ *
+ * @public
+ */
+export function useData<T>(
+  fetchDataAsync: () => Promise<T>,
+  options?: { autoLoad: boolean },
+): Data<T> {
+  const auto = options?.autoLoad ?? true;
+  const [{ data, loading, error }, dispatch] = useReducer(createReducer<T>(), {
+    loading: auto,
+  });
+  function reload() {
+    if (!loading) dispatch({ type: "loading" });
+    fetchDataAsync()
+      .then((data) => dispatch({ type: "result", result: data }))
+      .catch((error) => dispatch({ type: "error", error }));
+  }
+  useEffect(() => {
+    if (auto) reload();
+  }, []);
+  return { data, loading, error, reload };
+}

--- a/hello-world-tab-docker/src/components/sample/lib/useTeams.ts
+++ b/hello-world-tab-docker/src/components/sample/lib/useTeams.ts
@@ -1,0 +1,109 @@
+import { useEffect, useState } from "react";
+import { unstable_batchedUpdates as batchedUpdates } from "react-dom";
+import { app, pages } from "@microsoft/teams-js";
+import {
+  teamsLightTheme,
+  teamsDarkTheme,
+  teamsHighContrastTheme,
+  Theme,
+} from "@fluentui/react-components";
+const getTheme = (): string | undefined => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const theme = urlParams.get("theme");
+  return theme == null ? undefined : theme;
+};
+/**
+ * Microsoft Teams React hook
+ * @param options optional options
+ * @returns A tuple with properties and methods
+ * properties:
+ *  - inTeams: boolean = true if inside Microsoft Teams
+ *  - fullscreen: boolean = true if in full screen mode
+ *  - theme: Fluent UI Theme
+ *  - themeString: string - representation of the theme (default, dark or contrast)
+ *  - context - the Microsoft Teams JS SDK context
+ * methods:
+ *  - setTheme - manually set the theme
+ */
+export function useTeams(options?: {
+  initialTheme?: string;
+  setThemeHandler?: (theme?: string) => void;
+}): [
+  {
+    inTeams?: boolean;
+    fullScreen?: boolean;
+    theme: Theme;
+    themeString: string;
+    context?: app.Context;
+    loading?: boolean;
+  },
+  {
+    setTheme: (theme: string | undefined) => void;
+  },
+] {
+  const [loading, setLoading] = useState<boolean | undefined>(undefined);
+  const [inTeams, setInTeams] = useState<boolean | undefined>(undefined);
+  const [fullScreen, setFullScreen] = useState<boolean | undefined>(undefined);
+  const [theme, setTheme] = useState<Theme>(teamsLightTheme);
+  const [themeString, setThemeString] = useState<string>("default");
+  const [initialTheme] = useState<string | undefined>(
+    options && options.initialTheme ? options.initialTheme : getTheme(),
+  );
+  const [context, setContext] = useState<app.Context | undefined>(undefined);
+  const themeChangeHandler = (theme: string | undefined) => {
+    setThemeString(theme || "default");
+    switch (theme) {
+      case "dark":
+        setTheme(teamsDarkTheme);
+        break;
+      case "contrast":
+        setTheme(teamsHighContrastTheme);
+        break;
+      case "default":
+      default:
+        setTheme(teamsLightTheme);
+    }
+  };
+  const overrideThemeHandler = options?.setThemeHandler
+    ? options.setThemeHandler
+    : themeChangeHandler;
+  useEffect(() => {
+    // set initial theme based on options or query string
+    if (initialTheme) {
+      overrideThemeHandler(initialTheme);
+    }
+
+    app
+      .initialize()
+      .then(() => {
+        app
+          .getContext()
+          .then((context) => {
+            batchedUpdates(() => {
+              setInTeams(true);
+              setContext(context);
+              setFullScreen(context.page.isFullScreen);
+            });
+            overrideThemeHandler(context.app.theme);
+            app.registerOnThemeChangeHandler(overrideThemeHandler);
+            pages.registerFullScreenHandler((isFullScreen) => {
+              setFullScreen(isFullScreen);
+            });
+            setLoading(false);
+          })
+          .catch(() => {
+            setLoading(false);
+            setInTeams(false);
+          });
+      })
+      .catch(() => {
+        setLoading(false);
+        setInTeams(false);
+      });
+  }, []);
+
+  return [
+    { inTeams, fullScreen, theme, context, themeString, loading },
+    { setTheme: overrideThemeHandler },
+  ];
+}

--- a/hello-world-tab-with-backend/api/package.json
+++ b/hello-world-tab-with-backend/api/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "@azure/functions": "^4.2.0",
     "@microsoft/microsoft-graph-client": "^3.0.5",
-    "@microsoft/teamsfx": "^2.0.0",
+    "@azure/identity": "^4.4.1",
+    "jwt-decode": "^4.0.0",
     "hpagent": "^1.2.0",
     "isomorphic-fetch": "^3.0.0",
     "node-fetch": "^2.7.0"

--- a/hello-world-tab-with-backend/package.json
+++ b/hello-world-tab-with-backend/package.json
@@ -8,8 +8,7 @@
   "dependencies": {
     "@fluentui/react-components": "^9.18.0",
     "@microsoft/teams-js": "^2.22.0",
-    "@microsoft/teamsfx": "^2.2.0",
-    "@microsoft/teamsfx-react": "^3.0.0",
+    "@azure/msal-browser": "^4.12.0",
     "axios": "^0.21.1",
     "js-base64": "^3.7.7",
     "react": "^18.2.0",

--- a/hello-world-tab-with-backend/src/components/App.tsx
+++ b/hello-world-tab-with-backend/src/components/App.tsx
@@ -9,25 +9,21 @@ import {
 import { useEffect } from "react";
 import { HashRouter as Router, Navigate, Route, Routes } from "react-router-dom";
 import { app } from "@microsoft/teams-js";
-import { useTeamsUserCredential } from "@microsoft/teamsfx-react";
 import Privacy from "./Privacy";
 import TermsOfUse from "./TermsOfUse";
 import Tab from "./Tab";
 import TabConfig from "./TabConfig";
 import { TeamsFxContext } from "./Context";
-import config from "./sample/lib/config";
 // Only takes effect for proxy purpose when REACT_APP_HOOK_FOR_PROXY is set in the environment.
 import "./HookForProxy";
+import { useTeams } from "./sample/lib/useTeams";
 
 /**
  * The main app which handles the initialization and routing
  * of the app.
  */
 export default function App() {
-  const { loading, theme, themeString, teamsUserCredential } = useTeamsUserCredential({
-    initiateLoginEndpoint: config.initiateLoginEndpoint!,
-    clientId: config.clientId!,
-  });
+  const [{ loading, themeString, theme }] = useTeams();
   useEffect(() => {
     loading &&
       app.initialize().then(() => {
@@ -36,7 +32,7 @@ export default function App() {
       });
   }, [loading]);
   return (
-    <TeamsFxContext.Provider value={{ theme, themeString, teamsUserCredential }}>
+    <TeamsFxContext.Provider value={{ theme, themeString }}>
       <FluentProvider
         theme={
           themeString === "dark"

--- a/hello-world-tab-with-backend/src/components/Context.tsx
+++ b/hello-world-tab-with-backend/src/components/Context.tsx
@@ -1,13 +1,10 @@
-import { TeamsUserCredential } from "@microsoft/teamsfx";
 import { createContext } from "react";
 import { Theme } from "@fluentui/react-components";
 
 export const TeamsFxContext = createContext<{
   theme?: Theme;
   themeString: string;
-  teamsUserCredential?: TeamsUserCredential;
 }>({
   theme: undefined,
   themeString: "",
-  teamsUserCredential: undefined,
 });

--- a/hello-world-tab-with-backend/src/components/HookForProxy.tsx
+++ b/hello-world-tab-with-backend/src/components/HookForProxy.tsx
@@ -4,26 +4,20 @@
  * The backend code in api folder will send the Graph API request to proxy which will skip the access token check.
  */
 
-import { TeamsUserCredential } from "@microsoft/teamsfx";
-import { AccessToken } from "@azure/identity";
 import { Base64 } from "js-base64";
+import { authentication } from "@microsoft/teams-js";
 export function shouldHookForProxy(): boolean {
   return process.env.REACT_APP_HOOK_FOR_PROXY === "true";
 }
 
 if (shouldHookForProxy()) {
   // hook getToken to return a mocked access token. The token can not be used to call real Graph API.
-  TeamsUserCredential.prototype.getToken = async (scopes: string | string[], options?: any) => {
-    const accessToken: AccessToken = {
-      token: generateMockedAccessToken(),
-      expiresOnTimestamp: 2147483647,
-    };
-    return accessToken;
+  authentication.getAuthToken = async (authTokenRequest?: any) => {
+    return generateMockedAccessToken();
   };
 
-  // hook login to do nothing.
-  TeamsUserCredential.prototype.login = async (scopes: string | string[], options?: any) => {
-    return;
+  authentication.authenticate = async (authenticateParams?: any) => {
+    return "";
   };
 }
 

--- a/hello-world-tab-with-backend/src/components/sample/Welcome.tsx
+++ b/hello-world-tab-with-backend/src/components/sample/Welcome.tsx
@@ -1,4 +1,5 @@
-import { useContext, useState } from "react";
+import { useState } from "react";
+import { app } from "@microsoft/teams-js";
 import {
   Image,
   TabList,
@@ -11,10 +12,9 @@ import "./Welcome.css";
 import { EditCode } from "./EditCode";
 import { AzureFunctions } from "./AzureFunctions";
 import { CurrentUser } from "./CurrentUser";
-import { useData } from "@microsoft/teamsfx-react";
+import { useData } from "./lib/useData";
 import { Deploy } from "./Deploy";
 import { Publish } from "./Publish";
-import { TeamsFxContext } from "../Context";
 
 export function Welcome(props: { showFunction?: boolean; environment?: string }) {
   const { showFunction, environment } = {
@@ -33,11 +33,13 @@ export function Welcome(props: { showFunction?: boolean; environment?: string })
   const onTabSelect = (event: SelectTabEvent, data: SelectTabData) => {
     setSelectedValue(data.value);
   };
-  const { teamsUserCredential } = useContext(TeamsFxContext);
   const { loading, data, error } = useData(async () => {
-    if (teamsUserCredential) {
-      const userInfo = await teamsUserCredential.getUserInfo();
-      return userInfo;
+    await app.initialize();
+    const context = await app.getContext();
+    if (context.user) {
+      return {
+        displayName: context.user.displayName || "",
+      };
     }
   });
   const userName = loading || error ? "" : data!.displayName;

--- a/hello-world-tab-with-backend/src/components/sample/lib/config.ts
+++ b/hello-world-tab-with-backend/src/components/sample/lib/config.ts
@@ -1,6 +1,7 @@
 const config = {
   initiateLoginEndpoint: process.env.REACT_APP_START_LOGIN_PAGE_URL,
   clientId: process.env.REACT_APP_CLIENT_ID,
+  tenantId: process.env.TEAMS_APP_TENANT_ID,
   apiEndpoint: process.env.REACT_APP_FUNC_ENDPOINT,
   apiName: process.env.REACT_APP_FUNC_NAME,
 };

--- a/hello-world-tab-with-backend/src/components/sample/lib/useData.ts
+++ b/hello-world-tab-with-backend/src/components/sample/lib/useData.ts
@@ -1,0 +1,70 @@
+import { useEffect, useReducer } from "react";
+
+type State<T> = {
+  /**
+   * User data.
+   */
+  data?: T;
+  /**
+   * Status of data loading.
+   */
+  loading: boolean;
+  /**
+   * Error information.
+   */
+  error?: unknown;
+};
+
+type Action<T> =
+  | { type: "loading" }
+  | { type: "result"; result: T }
+  | { type: "error"; error: unknown };
+
+export type Data<T> = State<T> & {
+  /**
+   * reload function.
+   */
+  reload: () => void;
+};
+
+const createReducer =
+  <T>() =>
+  (state: State<T>, action: Action<T>): State<T> => {
+    switch (action.type) {
+      case "loading":
+        return { data: state.data, loading: true };
+      case "result":
+        return { data: action.result, loading: false };
+      case "error":
+        return { loading: false, error: action.error };
+    }
+  };
+
+/**
+ * Helper function to fetch data with status and error.
+ *
+ * @param fetchDataAsync - async function of how to fetch data
+ * @param options - if autoLoad is true, reload data immediately
+ * @returns data, loading status, error and reload function
+ *
+ * @public
+ */
+export function useData<T>(
+  fetchDataAsync: () => Promise<T>,
+  options?: { autoLoad: boolean },
+): Data<T> {
+  const auto = options?.autoLoad ?? true;
+  const [{ data, loading, error }, dispatch] = useReducer(createReducer<T>(), {
+    loading: auto,
+  });
+  function reload() {
+    if (!loading) dispatch({ type: "loading" });
+    fetchDataAsync()
+      .then((data) => dispatch({ type: "result", result: data }))
+      .catch((error) => dispatch({ type: "error", error }));
+  }
+  useEffect(() => {
+    if (auto) reload();
+  }, []);
+  return { data, loading, error, reload };
+}

--- a/hello-world-tab-with-backend/src/components/sample/lib/useTeams.ts
+++ b/hello-world-tab-with-backend/src/components/sample/lib/useTeams.ts
@@ -1,0 +1,109 @@
+import { useEffect, useState } from "react";
+import { unstable_batchedUpdates as batchedUpdates } from "react-dom";
+import { app, pages } from "@microsoft/teams-js";
+import {
+  teamsLightTheme,
+  teamsDarkTheme,
+  teamsHighContrastTheme,
+  Theme,
+} from "@fluentui/react-components";
+const getTheme = (): string | undefined => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const theme = urlParams.get("theme");
+  return theme == null ? undefined : theme;
+};
+/**
+ * Microsoft Teams React hook
+ * @param options optional options
+ * @returns A tuple with properties and methods
+ * properties:
+ *  - inTeams: boolean = true if inside Microsoft Teams
+ *  - fullscreen: boolean = true if in full screen mode
+ *  - theme: Fluent UI Theme
+ *  - themeString: string - representation of the theme (default, dark or contrast)
+ *  - context - the Microsoft Teams JS SDK context
+ * methods:
+ *  - setTheme - manually set the theme
+ */
+export function useTeams(options?: {
+  initialTheme?: string;
+  setThemeHandler?: (theme?: string) => void;
+}): [
+  {
+    inTeams?: boolean;
+    fullScreen?: boolean;
+    theme: Theme;
+    themeString: string;
+    context?: app.Context;
+    loading?: boolean;
+  },
+  {
+    setTheme: (theme: string | undefined) => void;
+  },
+] {
+  const [loading, setLoading] = useState<boolean | undefined>(undefined);
+  const [inTeams, setInTeams] = useState<boolean | undefined>(undefined);
+  const [fullScreen, setFullScreen] = useState<boolean | undefined>(undefined);
+  const [theme, setTheme] = useState<Theme>(teamsLightTheme);
+  const [themeString, setThemeString] = useState<string>("default");
+  const [initialTheme] = useState<string | undefined>(
+    options && options.initialTheme ? options.initialTheme : getTheme(),
+  );
+  const [context, setContext] = useState<app.Context | undefined>(undefined);
+  const themeChangeHandler = (theme: string | undefined) => {
+    setThemeString(theme || "default");
+    switch (theme) {
+      case "dark":
+        setTheme(teamsDarkTheme);
+        break;
+      case "contrast":
+        setTheme(teamsHighContrastTheme);
+        break;
+      case "default":
+      default:
+        setTheme(teamsLightTheme);
+    }
+  };
+  const overrideThemeHandler = options?.setThemeHandler
+    ? options.setThemeHandler
+    : themeChangeHandler;
+  useEffect(() => {
+    // set initial theme based on options or query string
+    if (initialTheme) {
+      overrideThemeHandler(initialTheme);
+    }
+
+    app
+      .initialize()
+      .then(() => {
+        app
+          .getContext()
+          .then((context) => {
+            batchedUpdates(() => {
+              setInTeams(true);
+              setContext(context);
+              setFullScreen(context.page.isFullScreen);
+            });
+            overrideThemeHandler(context.app.theme);
+            app.registerOnThemeChangeHandler(overrideThemeHandler);
+            pages.registerFullScreenHandler((isFullScreen) => {
+              setFullScreen(isFullScreen);
+            });
+            setLoading(false);
+          })
+          .catch(() => {
+            setLoading(false);
+            setInTeams(false);
+          });
+      })
+      .catch(() => {
+        setLoading(false);
+        setInTeams(false);
+      });
+  }, []);
+
+  return [
+    { inTeams, fullScreen, theme, context, themeString, loading },
+    { setTheme: overrideThemeHandler },
+  ];
+}

--- a/hello-world-teams-tab-and-outlook-add-in/tab/package.json
+++ b/hello-world-teams-tab-and-outlook-add-in/tab/package.json
@@ -2,15 +2,13 @@
   "name": "contoso-tab",
   "version": "0.1.0",
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "type": "module",
   "private": true,
   "dependencies": {
     "@fluentui/react-components": "^9.18.0",
     "@microsoft/teams-js": "^2.22.0",
-    "@microsoft/teamsfx": "^3.0.0-alpha",
-    "@microsoft/teamsfx-react": "^4.0.0-alpha",
     "axios": "^1.6.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/hello-world-teams-tab-and-outlook-add-in/tab/src/components/App.tsx
+++ b/hello-world-teams-tab-and-outlook-add-in/tab/src/components/App.tsx
@@ -6,7 +6,7 @@ import Privacy from "./Privacy";
 import TermsOfUse from "./TermsOfUse";
 import Tab from "./Tab";
 import TabConfig from "./TabConfig";
-import { useTeams } from "@microsoft/teamsfx-react";
+import { useTeams } from "./useTeams";
 
 /**
  * The main app which handles the initialization and routing

--- a/hello-world-teams-tab-and-outlook-add-in/tab/src/components/useTeams.tsx
+++ b/hello-world-teams-tab-and-outlook-add-in/tab/src/components/useTeams.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from "react";
+import { unstable_batchedUpdates as batchedUpdates } from "react-dom";
+import { app, pages } from "@microsoft/teams-js";
+import {
+  teamsLightTheme,
+  teamsDarkTheme,
+  teamsHighContrastTheme,
+} from "@fluentui/react-components";
+
+const getTheme = () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const theme = urlParams.get("theme");
+  return theme == null ? undefined : theme;
+};
+
+/**
+ * Microsoft Teams React hook
+ * @param {Object} options optional options
+ * @returns A tuple with properties and methods
+ * properties:
+ *  - inTeams: boolean = true if inside Microsoft Teams
+ *  - fullscreen: boolean = true if in full screen mode
+ *  - theme: Fluent UI Theme
+ *  - themeString: string - representation of the theme (default, dark or contrast)
+ *  - context - the Microsoft Teams JS SDK context
+ * methods:
+ *  - setTheme - manually set the theme
+ */
+export function useTeams(options) {
+  const [loading, setLoading] = useState(undefined);
+  const [inTeams, setInTeams] = useState(undefined);
+  const [fullScreen, setFullScreen] = useState(undefined);
+  const [theme, setTheme] = useState(teamsLightTheme);
+  const [themeString, setThemeString] = useState("default");
+  const [initialTheme] = useState(
+    options && options.initialTheme ? options.initialTheme : getTheme()
+  );
+  const [context, setContext] = useState(undefined);
+
+  const themeChangeHandler = (theme) => {
+    setThemeString(theme || "default");
+    switch (theme) {
+      case "dark":
+        setTheme(teamsDarkTheme);
+        break;
+      case "contrast":
+        setTheme(teamsHighContrastTheme);
+        break;
+      case "default":
+      default:
+        setTheme(teamsLightTheme);
+    }
+  };
+
+  const overrideThemeHandler = options?.setThemeHandler
+    ? options.setThemeHandler
+    : themeChangeHandler;
+
+  useEffect(() => {
+    // set initial theme based on options or query string
+    if (initialTheme) {
+      overrideThemeHandler(initialTheme);
+    }
+
+    app
+      .initialize()
+      .then(() => {
+        app
+          .getContext()
+          .then((context) => {
+            batchedUpdates(() => {
+              setInTeams(true);
+              setContext(context);
+              setFullScreen(context.page.isFullScreen);
+            });
+            overrideThemeHandler(context.app.theme);
+            app.registerOnThemeChangeHandler(overrideThemeHandler);
+            pages.registerFullScreenHandler((isFullScreen) => {
+              setFullScreen(isFullScreen);
+            });
+            setLoading(false);
+          })
+          .catch(() => {
+            setLoading(false);
+            setInTeams(false);
+          });
+      })
+      .catch(() => {
+        setLoading(false);
+        setInTeams(false);
+      });
+  }, [initialTheme, overrideThemeHandler]);
+
+  return [
+    {
+      inTeams,
+      fullScreen,
+      theme,
+      themeString,
+      context,
+      loading,
+    },
+    {
+      setTheme: (theme) => {
+        overrideThemeHandler(theme);
+      },
+    },
+  ];
+}


### PR DESCRIPTION
Remove `@microsoft/teamsfx` and `@microsoft/teamsfx-react` dependency, add some hooks to source code.

- hello-world-in-meeting
- hello-world-tab-codespaces
- hello-world-bot-with-tab
- hello-world-teams-tab-and-outlook-add-in
- hello-world-tab-with-backend
- hello-world-tab-docker

Fix one bug in previous PR: #1440  bot-sso-docker sample.
