### PR TITLE
feat: add da sample type

### DIFF
--- a/.config/samples-config-v3.json
+++ b/.config/samples-config-v3.json
@@ -1,6 +1,7 @@
 {
     "filterOptions": {
         "capabilities": [
+            "Declarative Agent",
             "Tab",
             "Bot",
             "Message Extension",


### PR DESCRIPTION
Add a new sample type "Declarative Agent".
Feature: https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/33259089/