### PR TITLE
fix: command-bot-sso signin fail

### DIFF
--- a/command-bot-with-sso/src/index.ts
+++ b/command-bot-with-sso/src/index.ts
@@ -52,7 +52,7 @@ const app = new ApplicationBuilder()
             }
         },
         autoSignIn: (context) => {
-          if (context.activity.type == "message" && context.activity.text != "profile" || context.activity.text != "photo") {
+          if (context.activity.type == "message" && (context.activity.text != "profile" && context.activity.text != "photo")) {
             return Promise.resolve(false);
           }
           return Promise.resolve(true);


### PR DESCRIPTION
wrong if statement for autosignin check.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/32982444