### PR TITLE
fix: avoid infinite loading status

### DIFF
--- a/copilot-connector-app/tabs/src/components/sample/lib/useData.ts
+++ b/copilot-connector-app/tabs/src/components/sample/lib/useData.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer } from "react";
+import { useCallback, useEffect, useReducer, useRef } from "react";
 
 type State<T> = {
   /**
@@ -57,17 +57,21 @@ export function useData<T>(
   const [{ data, loading, error }, dispatch] = useReducer(createReducer<T>(), {
     loading: auto,
   });
+  const fetchDataRef = useRef(fetchDataAsync);
+  fetchDataRef.current = fetchDataAsync;
   const reload = useCallback(
     () => {
       if (!loading) dispatch({ type: "loading" });
-      fetchDataAsync()
+      fetchDataRef.current()
         .then((data) => dispatch({ type: "result", result: data }))
         .catch((error) => dispatch({ type: "error", error }));
-    },
-    [fetchDataAsync, loading]
-  );
+  }, [loading]);
+  const hasLoadedRef = useRef(false);
   useEffect(() => {
-    if (auto) reload();
+    if (auto && !hasLoadedRef.current) {
+      hasLoadedRef.current = true;
+      reload();
+    }
   }, [auto, reload]);
   return { data, loading, error, reload };
 }


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33996198

Bug introduced by: https://github.com/OfficeDev/microsoft-365-agents-toolkit-samples/pull/1472

Instead of including fetchDataAsync in the dependency array (which would recreate reload), store it in a ref and always call the latest version. To avoid infinite loop.

Verified:
<img width="1754" height="1106" alt="image" src="https://github.com/user-attachments/assets/cb32187a-51af-451e-b40a-4010e07c28ea" />
