### PR TITLE
fix: remove tab with azure backend and large scale samples from featured

### DIFF
--- a/.config/samples-config-v3.json
+++ b/.config/samples-config-v3.json
@@ -45,7 +45,7 @@
             "configuration": "Ready for debug",
             "thumbnailPath": "assets/thumbnail.png",
             "gifPath": "assets/sampleDemo.gif",
-            "suggested": true
+            "suggested": false
         },
         {
             "id": "graph-toolkit-contact-exporter",
@@ -568,7 +568,7 @@
             "configuration": "Manual configurations required",
             "gifPath": "assets/thumbnail.png",
             "thumbnailPath": "assets/thumbnail.png",
-            "suggested": true
+            "suggested": false
         },
         {
             "id": "bot-conversation-python",


### PR DESCRIPTION
cherry pick https://github.com/OfficeDev/microsoft-365-agents-toolkit-samples/pull/1523