### PR TITLE
fix: set node version to 20 as 18 is deprecated in azure function

### DIFF
--- a/large-scale-notification/infra/azure.bicep
+++ b/large-scale-notification/infra/azure.bicep
@@ -193,7 +193,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~18' // Set NodeJS version to 18.x
+          value: '~20' // Set NodeJS version to 20.x
         }
         {
           name: 'clientId'


### PR DESCRIPTION
# Pull Request

## Description

fix [bug](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_queries/edit/35873035) for large-scale-notification sample

## Type of Change

- [ ] New sample onboarding (internal - source code in this repo)
- [ ] New sample onboarding (external - source code in another repo)
- [x] Sample update/fix
- [ ] Documentation update
- [ ] Validation tool update
- [ ] Other (please describe)


