### PR TITLE
chore: update Node.js version from 18 to 20 for Azure Function apps

### DIFF
--- a/adaptive-card-notification/README.md
+++ b/adaptive-card-notification/README.md
@@ -25,7 +25,7 @@ Adaptive Card Notification provides an easy way to send notification in Teams. T
 
 ## Prerequisite to use this sample
 
-- [Node.js](https://nodejs.org/), supported versions: 18, 20, 22
+- [Node.js](https://nodejs.org/), supported versions: 20, 22
 - A Microsoft 365 tenant in which you have permission to upload Teams apps. You can get a free Microsoft 365 developer tenant by joining the [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program).
 - [Microsoft 365 Agents Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teams-toolkit-cli)
 - An [Azure subscription](https://azure.microsoft.com/en-us/free/)

--- a/adaptive-card-notification/infra/azure.bicep
+++ b/adaptive-card-notification/infra/azure.bicep
@@ -54,7 +54,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~18' // Set NodeJS version to 18.x
+          value: '~20' // Set NodeJS version to 20.x
         }
         {
           name: 'clientId'

--- a/copilot-connector-app/README.md
+++ b/copilot-connector-app/README.md
@@ -25,7 +25,7 @@ This sample app showcases how to build custom Copilot connector with Azure Funct
 - How to use Microsoft Graph API to build a custom Copilot connector.
 
 ## Prerequisite to use this sample
-- [Node.js](https://nodejs.org/), supported versions: 18, 20, 22
+- [Node.js](https://nodejs.org/), supported versions: 20, 22
 - An [Azure subscription](https://azure.microsoft.com/en-us/free/)
 - A Microsoft 365 account. If you do not have Microsoft 365 account, apply one from [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - [Microsoft 365 Agents Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teams-toolkit-cli)

--- a/copilot-connector-app/infra/azure.bicep
+++ b/copilot-connector-app/infra/azure.bicep
@@ -77,7 +77,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~18' // Set NodeJS version to 18.x
+          value: '~20' // Set NodeJS version to 20.x
         }
         {
           name: 'ALLOWED_APP_IDS'

--- a/developer-assist-dashboard/README.md
+++ b/developer-assist-dashboard/README.md
@@ -30,7 +30,7 @@ Developer Assist Dashboard shows you how to build a tab with Azure DevOps work i
 
 ## Prerequisite to use this sample
 
-- [Node.js](https://nodejs.org/), supported versions: 18, 20, 22
+- [Node.js](https://nodejs.org/), supported versions: 20, 22
 - A Microsoft 365 tenant in which you have permission to upload Teams apps. You can get a free Microsoft 365 developer tenant by joining the [M365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - [Microsoft 365 Agents Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teams-toolkit-cli)
 

--- a/developer-assist-dashboard/infra/azure.bicep
+++ b/developer-assist-dashboard/infra/azure.bicep
@@ -93,7 +93,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~18' // Set NodeJS version to 18.x
+          value: '~20' // Set NodeJS version to 20.x
         }
         {
           name: 'ALLOWED_APP_IDS'

--- a/hello-world-tab-with-backend/README.md
+++ b/hello-world-tab-with-backend/README.md
@@ -29,7 +29,7 @@ Hello World Tab with Backend shows you how to build a tab app with an Azure Func
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/), supported versions: 18, 20, 22
+- [Node.js](https://nodejs.org/), supported versions: 20, 22
 - A Microsoft 365 account. If you do not have Microsoft 365 account, apply one from [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - [Microsoft 365 Agents Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teams-toolkit-cli)
 

--- a/hello-world-tab-with-backend/api/README.md
+++ b/hello-world-tab-with-backend/api/README.md
@@ -4,7 +4,7 @@ Azure Functions are a great way to add server-side behaviors to any Teams applic
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/), supported versions: 18, 20, 22
+- [Node.js](https://nodejs.org/), supported versions: 20, 22
 - A Microsoft 365 account. If you do not have Microsoft 365 account, apply one from [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - [Microsoft 365 Agents Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teams-toolkit-cli)
 
@@ -45,7 +45,7 @@ By default, Microsoft 365 Agents Toolkit and Microsoft 365 Agents Toolkit CLI wi
 - Sign in to [Azure Portal](https://azure.microsoft.com/).
 - Find your application's resource group and Azure Function app resource. The resource group name and the Azure function app name are stored in your project configuration file `.fx/env.*.json`. You can find them by searching the key `resourceGroupName` and `functionAppName` in that file.
 - After enter the home page of the Azure function app, you can find a navigation item called `Configuration` under `settings` group.
-- Click `Configuration`, you would see a list of settings. Then click `WEBSITE_NODE_DEFAULT_VERSION` and update the value to `~16` or `~18` according to your requirement.
+- Click `Configuration`, you would see a list of settings. Then click `WEBSITE_NODE_DEFAULT_VERSION` and update the value to `~20` according to your requirement.
 - After Click `OK` button, don't forget to click `Save` button on the top of the page.
 
 Then following requests sent to the Azure function app will be handled by new node runtime version.

--- a/hello-world-tab-with-backend/infra/azure.bicep
+++ b/hello-world-tab-with-backend/infra/azure.bicep
@@ -78,7 +78,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~18' // Set NodeJS version to 18.x
+          value: '~20' // Set NodeJS version to 20.x
         }
         {
           name: 'ALLOWED_APP_IDS'

--- a/intelligent-data-chart-generator/README.md
+++ b/intelligent-data-chart-generator/README.md
@@ -28,7 +28,7 @@ This intelligent Microsoft Teams Tab app is powered by Azure OpenAI, which helps
 
 ## Prerequisite to use this sample
 
-- [Node.js](https://nodejs.org/), supported versions: 18, 20, 22
+- [Node.js](https://nodejs.org/), supported versions: 20, 22
 - A Microsoft 365 tenant in which you have permission to upload Teams apps. You can get a free Microsoft 365 developer tenant by joining the [M365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - An [Azure OpenAI](https://aka.ms/azureopenai) resource and an [Azure SQL Database](https://aka.ms/azuredb) resource.
 - [Microsoft 365 Agents Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)

--- a/intelligent-data-chart-generator/infra/azure.bicep
+++ b/intelligent-data-chart-generator/infra/azure.bicep
@@ -93,7 +93,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~18' // Set NodeJS version to 18.x
+          value: '~20' // Set NodeJS version to 20.x
         }
         {
           name: 'ALLOWED_APP_IDS'

--- a/share-now/README.md
+++ b/share-now/README.md
@@ -26,7 +26,7 @@ Share Now promotes the exchange of information between colleagues by enabling us
 - How to connect to Azure SQL DB and how to do CRUD operations in DB.
 
 ## Prerequisite
-- [Node.js](https://nodejs.org/), supported versions: 18, 20, 22
+- [Node.js](https://nodejs.org/), supported versions: 20, 22
 - A Microsoft 365 account. If you do not have Microsoft 365 account, apply one from [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - [Microsoft 365 Agents Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teams-toolkit-cli)
 - An [Azure subscription](https://azure.microsoft.com/en-us/free/)

--- a/share-now/infra/provision/function.bicep
+++ b/share-now/infra/provision/function.bicep
@@ -40,7 +40,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~18'
+          value: '~20'
         }
       ]
     }

--- a/stocks-update-notification-bot/README.md
+++ b/stocks-update-notification-bot/README.md
@@ -24,7 +24,7 @@ The Stocks Update Notification bot shows you how to request data on a pretermine
 - How to use a bot in different contexts
 
 ## Prerequisite to use this sample
-- [Node.js](https://nodejs.org/), supported versions: 18, 20, 22
+- [Node.js](https://nodejs.org/), supported versions: 20, 22
 - A Microsoft 365 account. If you do not have Microsoft 365 account, apply one from [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - [Microsoft 365 Agents Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teams-toolkit-cli)
 

--- a/stocks-update-notification-bot/infra/azure.bicep
+++ b/stocks-update-notification-bot/infra/azure.bicep
@@ -57,7 +57,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~18' // Set NodeJS version to 18.x
+          value: '~20' // Set NodeJS version to 20.x
         }
         {
           name: 'clientId'

--- a/team-central-dashboard/README.md
+++ b/team-central-dashboard/README.md
@@ -30,7 +30,7 @@ Team Central Dashboard shows you how to build a tab with data chats and content 
 
 ## Prerequisite to use this sample
 
-- [Node.js](https://nodejs.org/), supported versions: 18, 20, 22
+- [Node.js](https://nodejs.org/), supported versions: 20, 22
 - A Microsoft 365 tenant in which you have permission to upload Teams apps. You can get a free Microsoft 365 developer tenant by joining the [M365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - [Microsoft 365 Agents Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teams-toolkit-cli)
 

--- a/team-central-dashboard/infra/azure.bicep
+++ b/team-central-dashboard/infra/azure.bicep
@@ -80,7 +80,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~18' // Set NodeJS version to 18.x
+          value: '~20' // Set NodeJS version to 20.x
         }
         {
           name: 'ALLOWED_APP_IDS'

--- a/todo-list-with-Azure-backend-M365/README.md
+++ b/todo-list-with-Azure-backend-M365/README.md
@@ -25,7 +25,7 @@ Todo List app helps to manage your personal to do items. This app can be install
 - How to use Microsoft 365 Agents Toolkit to build a personal tab app with Azure Function backend that runs across Microsoft 365 including Teams, Outlook and the Microsoft 365 app.
 
 ## Prerequisite to use this sample
-- [Node.js](https://nodejs.org/), supported versions: 18, 20, 22
+- [Node.js](https://nodejs.org/), supported versions: 20, 22
 - An [Azure subscription](https://azure.microsoft.com/en-us/free/)
 - [Set up your dev environment for extending Teams apps across Microsoft 365](https://aka.ms/teamsfx-m365-apps-prerequisites)
 - [Microsoft 365 Agents Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teams-toolkit-cli)

--- a/todo-list-with-Azure-backend-M365/infra/provision/function.bicep
+++ b/todo-list-with-Azure-backend-M365/infra/provision/function.bicep
@@ -43,7 +43,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~18' // Set NodeJS version to 18.x
+          value: '~20' // Set NodeJS version to 20.x
         }
       ]
       ftpsState: 'FtpsOnly'

--- a/todo-list-with-Azure-backend/README.md
+++ b/todo-list-with-Azure-backend/README.md
@@ -28,7 +28,7 @@ Todo List provides an easy way to manage to-do items in Teams Client. This app h
 - How to use TeamsFx simple auth capability to get Teams user login information.
 
 ## Prerequisite to use this sample
-- [Node.js](https://nodejs.org/), supported versions: 18, 20, 22
+- [Node.js](https://nodejs.org/), supported versions: 20, 22
 - A Microsoft 365 account. If you do not have Microsoft 365 account, apply one from [Microsoft 365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
 - [Microsoft 365 Agents Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teams-toolkit-cli)
 - An [Azure subscription](https://azure.microsoft.com/en-us/free/)

--- a/todo-list-with-Azure-backend/infra/provision/function.bicep
+++ b/todo-list-with-Azure-backend/infra/provision/function.bicep
@@ -40,7 +40,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~18'
+          value: '~20'
         }
       ]
     }


### PR DESCRIPTION
## Summary
Azure Functions has deprecated Node.js 18. This PR updates the Node.js version configuration for all samples using Azure Function apps.

## Changes
- Updated WEBSITE_NODE_DEFAULT_VERSION from ~18 to ~20 in bicep files for all samples with kind: 'functionapp'
- Updated corresponding README files to reflect the supported Node.js versions (20, 22)

## Affected Samples
- adaptive-card-notification
- copilot-connector-app  
- developer-assist-dashboard
- hello-world-tab-with-backend
- intelligent-data-chart-generator
- large-scale-notification (via share-now)
- share-now
- stocks-update-notification-bot
- team-central-dashboard
- todo-list-with-Azure-backend
- todo-list-with-Azure-backend-M365

## Notes
Only kind: 'functionapp' resources are affected. kind: 'app' resources remain unchanged as they use Azure App Service which still supports Node.js 18.

## Related Bug
[35959986](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/35959986/) sample "hello world tab with backend" remote debug call azure function failed