### PR TITLE
fix(intelligent-data-chart-generator): fix AppInitTimeout and TypeScript errors

### DIFF
--- a/intelligent-data-chart-generator/api/tsconfig.json
+++ b/intelligent-data-chart-generator/api/tsconfig.json
@@ -10,6 +10,6 @@
     "resolveJsonModule": true,
     "typeRoots": ["./node_modules/@types"],
     "allowSyntheticDefaultImports": true,
-    "moduleResolution": "node"
+    "moduleResolution": "NodeNext"
   }
 }

--- a/intelligent-data-chart-generator/src/App.tsx
+++ b/intelligent-data-chart-generator/src/App.tsx
@@ -24,11 +24,11 @@ export default function App() {
   const [{ loading, themeString }] = useTeams();
   
   useEffect(() => {
-    loading &&
-      app.initialize().then(() => {
-        // Hide the loading indicator.
-        app.notifySuccess();
-      });
+    // Notify Teams that the app is ready once loading is complete
+    // app.initialize() is already called in useTeams hook, don't call it again
+    if (loading === false) {
+      app.notifySuccess();
+    }
   }, [loading]);
   return (
     <TeamsFxContext.Provider value={{ themeString }}>


### PR DESCRIPTION
## Summary
This PR fixes two bugs in the intelligent-data-chart-generator sample:

### 1. AppInitTimeout Error (src/App.tsx)
The app.initialize() was being called twice - once in the useTeams hook and again in App.tsx useEffect. This caused Teams SDK initialization issues when idle.

Fix: Removed duplicate app.initialize() call. Now only app.notifySuccess() is called after useTeams completes.

### 2. TypeScript Compilation Error TS5109 (api/tsconfig.json)
moduleResolution must be NodeNext when module is NodeNext.

Fix: Changed moduleResolution from node to NodeNext.

## Testing
- TypeScript compiles without errors
- App loads in Teams without AppInitTimeout
- Frontend and backend start correctly