### PR TITLE
chore: align ProxyAgent sample manifests with toolkit #15358

### DIFF
--- a/ProxyAgent-CSharp/M365Agent/appPackage/manifest.json
+++ b/ProxyAgent-CSharp/M365Agent/appPackage/manifest.json
@@ -1,6 +1,6 @@
 {
- "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.24/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.24",
+ "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.25/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.25",
   "version": "1.0.0",
   "id": "${{TEAMS_APP_ID}}",
   "developer": {
@@ -22,6 +22,7 @@
     "full": "Custom engine agent that integrates Azure services with Microsoft 365 Copilot for enhanced productivity"
   },
   "accentColor": "#FFFFFF",
+  "supportsChannelFeatures": "tier1",
   "copilotAgents": {
     "customEngineAgents": [
       {

--- a/ProxyAgent-NodeJS/appPackage/manifest.json
+++ b/ProxyAgent-NodeJS/appPackage/manifest.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.24/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.24",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.25/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.25",
   "version": "1.0.0",
   "id": "${{TEAMS_APP_ID}}",
   "developer": {
@@ -22,6 +22,7 @@
     "full": "Custom engine agent that integrates Azure services with Microsoft 365 Copilot for enhanced productivity"
   },
   "accentColor": "#FFFFFF",
+  "supportsChannelFeatures": "tier1",
   "copilotAgents": {
     "customEngineAgents": [
       {


### PR DESCRIPTION
## Description
Align sample manifests with toolkit change from OfficeDev/microsoft-365-agents-toolkit#15358.

### What changed
- Update Teams app manifest schema from `v1.24` to `v1.25`
- Update `manifestVersion` from `1.24` to `1.25`
- Add `supportsChannelFeatures: "tier1"`

### Files updated
- `ProxyAgent-NodeJS/appPackage/manifest.json`
- `ProxyAgent-CSharp/M365Agent/appPackage/manifest.json`

## Validation
- JSON parse check passed for both manifests using PowerShell `ConvertFrom-Json`.

## Related
- OfficeDev/microsoft-365-agents-toolkit PR #15358
