### PR TITLE
fix: update graph-rsc-helper download path after repo restructure

### DIFF
--- a/.config/samples-config-v3.json
+++ b/.config/samples-config-v3.json
@@ -806,7 +806,7 @@
                 "owner": "OfficeDev",
                 "repository": "Microsoft-Teams-Samples",
                 "ref": "main",
-                "dir": "samples/graph-rsc-helper/nodeJs"
+                "dir": "samples/TeamsJS/graph-rsc-helper/nodeJs"
             }
         },
         {


### PR DESCRIPTION
## Summary

The Microsoft-Teams-Samples repo recently restructured its folder structure, moving nodejs samples under \samples/TeamsJS/\.

This PR updates the \graph-rsc-helper\ sample's \downloadUrlInfo.dir\ from:
- \samples/graph-rsc-helper/nodeJs\ (old, now 404)

to:
- \samples/TeamsJS/graph-rsc-helper/nodeJs\ (new, valid)

## Verification

- Confirmed the old path returns 404: https://github.com/OfficeDev/Microsoft-Teams-Samples/tree/main/samples/graph-rsc-helper/nodeJs
- Confirmed the new path is valid: https://github.com/OfficeDev/Microsoft-Teams-Samples/tree/main/samples/TeamsJS/graph-rsc-helper/nodeJs
- All other 4 Microsoft-Teams-Samples references were checked and still resolve correctly.