### PR TITLE
fix: update msgext-link-unfurling-reddit directory path

### DIFF
--- a/.config/samples-config-v3.json
+++ b/.config/samples-config-v3.json
@@ -732,7 +732,7 @@
                 "owner": "OfficeDev",
                 "repository": "Microsoft-Teams-Samples",
                 "ref": "main",
-                "dir": "samples/msgext-link-unfurling-reddit/nodejs"
+                "dir": "samples/TeamsJS/msgext-link-unfurling-reddit/nodejs"
             }
         },
         {


### PR DESCRIPTION
Update the directory path for msgext-link-unfurling-reddit sample from `samples/msgext-link-unfurling-reddit/nodejs` to `samples/TeamsJS/msgext-link-unfurling-reddit/nodejs` to reflect the repo restructure in Microsoft-Teams-Samples.
[workitem](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/37157720)