### PR TITLE
fix(apim-genai-gateway): correct APIM subscription scope from api.id to api.name

### DIFF
--- a/apim-genai-gateway/infra/apim-new-ai-service/modules/apiBackends.bicep
+++ b/apim-genai-gateway/infra/apim-new-ai-service/modules/apiBackends.bicep
@@ -154,7 +154,7 @@ resource apimSubscription 'Microsoft.ApiManagement/service/subscriptions@2023-05
   properties: {
     allowTracing: true
     displayName: 'AI Services Subscription'
-    scope: '/apis/${api.id}'
+    scope: '/apis/${api.name}'
     state: 'active'
   }
 }

--- a/apim-genai-gateway/m365agents.local.yml
+++ b/apim-genai-gateway/m365agents.local.yml
@@ -60,7 +60,8 @@ provision:
       shell: pwsh
       run: |
         $url = 'https://management.azure.com/subscriptions/${{AZURE_SUBSCRIPTION_ID}}/resourceGroups/${{AZURE_RESOURCE_GROUP_NAME}}/providers/Microsoft.ApiManagement/service/${{APIM_SERVICE_NAME}}/subscriptions/${{APIM_SUBSCRIPTION_NAME}}/listSecrets?api-version=2021-08-01'
-        $key = az rest --method post --url $url --query primaryKey -o tsv
+        $key = (az rest --method post --url $url --query primaryKey -o tsv).Trim()
+        if (-not $key) { Write-Error "Failed to retrieve APIM subscription key. Ensure Azure CLI is logged in and has access to the APIM service."; exit 1 }
         $content = Get-Content env/.env.local.user
         $filtered = @()
         foreach ($line in $content) {

--- a/apim-genai-gateway/m365agents.playground.yml
+++ b/apim-genai-gateway/m365agents.playground.yml
@@ -24,7 +24,8 @@ provision:
         shell: pwsh
         run: |
           $url = 'https://management.azure.com/subscriptions/${{AZURE_SUBSCRIPTION_ID}}/resourceGroups/${{AZURE_RESOURCE_GROUP_NAME}}/providers/Microsoft.ApiManagement/service/${{APIM_SERVICE_NAME}}/subscriptions/${{APIM_SUBSCRIPTION_NAME}}/listSecrets?api-version=2021-08-01'
-          $key = az rest --method post --url $url --query primaryKey -o tsv
+          $key = (az rest --method post --url $url --query primaryKey -o tsv).Trim()
+          if (-not $key) { Write-Error "Failed to retrieve APIM subscription key. Ensure Azure CLI is logged in and has access to the APIM service."; exit 1 }
           $content = Get-Content env/.env.playground.user
           $filtered = @()
           foreach ($line in $content) {


### PR DESCRIPTION
## Summary

Fixes **ADO Bug [36459206](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/36459206)**: *[VSC] Sample 'Custom Engine Agent using APIM GenAI Gateway' has local debug issue*

Users get a **401 Access denied** at runtime on Windows (or `ScriptExecutionError` on Linux) when local-debugging the `apim-genai-gateway` sample, even though `atk provision` succeeds.

## Root Cause

In `apiBackends.bicep`, the APIM subscription was created with:

```bicep
scope: '/apis/${api.id}'
```

In Bicep, `api.id` is the **full ARM resource ID**:
```
/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ApiManagement/service/{name}/apis/AIServices
```

Prepending `/apis/` produces a double-prefixed, malformed scope:
```
/apis//subscriptions/{sub}/.../apis/AIServices   ← invalid
```

ARM creates the subscription resource without validating the scope string (so `arm/deploy` succeeds), but APIM validates it on every incoming request and rejects with **401 Access denied due to invalid subscription key**.

## Fix

### 1. `apiBackends.bicep` — correct the scope (root cause)

```bicep
// Before
scope: '/apis/${api.id}'

// After
scope: '/apis/${api.name}'
```

With `parent: apimService` set on the `api` resource, `api.name` returns only the child segment (`AIServices`), giving the correct APIM scope `/apis/AIServices`.

### 2. `m365agents.local.yml` / `m365agents.playground.yml` — robustness fix

Added `.Trim()` and an explicit error guard to the `az rest` key retrieval script to prevent silent failures from trailing whitespace or missing credentials.

## Verification

- `atk provision --env local` ran all 10 lifecycle steps successfully, including `arm/deploy` (APIM + AI Services) and the `script` step that writes `SECRET_AZURE_OPENAI_API_KEY`
- `atk deploy --env local` succeeded
- Bot started and was tested via `teamsapptester` (Path A — playground-cli):
  - Sent: *"Hello! What can you help me with?"*
  - Received full LLM response via APIM → Azure OpenAI
  - HTTP log showed **200** — no 401 anywhere