### PR TITLE
fix(sso-tabs): add missing blank-auth-end.html to all affected tab samples (ADO Bug 36195045)

### DIFF
--- a/copilot-connector-app/tabs/public/blank-auth-end.html
+++ b/copilot-connector-app/tabs/public/blank-auth-end.html
@@ -1,0 +1,11 @@
+<!--This file is used as the redirect URI for silent MSAL token acquisition (ssoSilent / acquireTokenSilent).-->
+<!--MSAL opens a hidden iframe pointing to this page; it monitors the iframe URL for the auth code in the hash.-->
+<!--The page must exist so that the browser navigates here successfully instead of falling back to the SPA shell.-->
+<html>
+  <head>
+    <title>Blank Auth End Page</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+  </body>
+</html>

--- a/developer-assist-dashboard/public/blank-auth-end.html
+++ b/developer-assist-dashboard/public/blank-auth-end.html
@@ -1,0 +1,11 @@
+<!--This file is used as the redirect URI for silent MSAL token acquisition (ssoSilent / acquireTokenSilent).-->
+<!--MSAL opens a hidden iframe pointing to this page; it monitors the iframe URL for the auth code in the hash.-->
+<!--The page must exist so that the browser navigates here successfully instead of falling back to the SPA shell.-->
+<html>
+  <head>
+    <title>Blank Auth End Page</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+  </body>
+</html>

--- a/graph-toolkit-contact-exporter/public/blank-auth-end.html
+++ b/graph-toolkit-contact-exporter/public/blank-auth-end.html
@@ -1,0 +1,11 @@
+<!--This file is used as the redirect URI for silent MSAL token acquisition (ssoSilent / acquireTokenSilent).-->
+<!--MSAL opens a hidden iframe pointing to this page; it monitors the iframe URL for the auth code in the hash.-->
+<!--The page must exist so that the browser navigates here successfully instead of falling back to the SPA shell.-->
+<html>
+  <head>
+    <title>Blank Auth End Page</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+  </body>
+</html>

--- a/graph-toolkit-one-productivity-hub/public/blank-auth-end.html
+++ b/graph-toolkit-one-productivity-hub/public/blank-auth-end.html
@@ -1,0 +1,11 @@
+<!--This file is used as the redirect URI for silent MSAL token acquisition (ssoSilent / acquireTokenSilent).-->
+<!--MSAL opens a hidden iframe pointing to this page; it monitors the iframe URL for the auth code in the hash.-->
+<!--The page must exist so that the browser navigates here successfully instead of falling back to the SPA shell.-->
+<html>
+  <head>
+    <title>Blank Auth End Page</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+  </body>
+</html>

--- a/hello-world-tab-docker/public/blank-auth-end.html
+++ b/hello-world-tab-docker/public/blank-auth-end.html
@@ -1,0 +1,11 @@
+<!--This file is used as the redirect URI for silent MSAL token acquisition (ssoSilent / acquireTokenSilent).-->
+<!--MSAL opens a hidden iframe pointing to this page; it monitors the iframe URL for the auth code in the hash.-->
+<!--The page must exist so that the browser navigates here successfully instead of falling back to the SPA shell.-->
+<html>
+  <head>
+    <title>Blank Auth End Page</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+  </body>
+</html>

--- a/hello-world-tab-with-backend/public/blank-auth-end.html
+++ b/hello-world-tab-with-backend/public/blank-auth-end.html
@@ -1,0 +1,11 @@
+<!--This file is used as the redirect URI for silent MSAL token acquisition (ssoSilent / acquireTokenSilent).-->
+<!--MSAL opens a hidden iframe pointing to this page; it monitors the iframe URL for the auth code in the hash.-->
+<!--The page must exist so that the browser navigates here successfully instead of falling back to the SPA shell.-->
+<html>
+  <head>
+    <title>Blank Auth End Page</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+  </body>
+</html>

--- a/intelligent-data-chart-generator/public/blank-auth-end.html
+++ b/intelligent-data-chart-generator/public/blank-auth-end.html
@@ -1,0 +1,11 @@
+<!--This file is used as the redirect URI for silent MSAL token acquisition (ssoSilent / acquireTokenSilent).-->
+<!--MSAL opens a hidden iframe pointing to this page; it monitors the iframe URL for the auth code in the hash.-->
+<!--The page must exist so that the browser navigates here successfully instead of falling back to the SPA shell.-->
+<html>
+  <head>
+    <title>Blank Auth End Page</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+  </body>
+</html>

--- a/share-now/tabs/public/blank-auth-end.html
+++ b/share-now/tabs/public/blank-auth-end.html
@@ -1,0 +1,11 @@
+<!--This file is used as the redirect URI for silent MSAL token acquisition (ssoSilent / acquireTokenSilent).-->
+<!--MSAL opens a hidden iframe pointing to this page; it monitors the iframe URL for the auth code in the hash.-->
+<!--The page must exist so that the browser navigates here successfully instead of falling back to the SPA shell.-->
+<html>
+  <head>
+    <title>Blank Auth End Page</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+  </body>
+</html>

--- a/team-central-dashboard/public/blank-auth-end.html
+++ b/team-central-dashboard/public/blank-auth-end.html
@@ -1,0 +1,11 @@
+<!--This file is used as the redirect URI for silent MSAL token acquisition (ssoSilent / acquireTokenSilent).-->
+<!--MSAL opens a hidden iframe pointing to this page; it monitors the iframe URL for the auth code in the hash.-->
+<!--The page must exist so that the browser navigates here successfully instead of falling back to the SPA shell.-->
+<html>
+  <head>
+    <title>Blank Auth End Page</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+  </body>
+</html>

--- a/todo-list-with-Azure-backend-M365/tabs/public/blank-auth-end.html
+++ b/todo-list-with-Azure-backend-M365/tabs/public/blank-auth-end.html
@@ -1,0 +1,11 @@
+<!--This file is used as the redirect URI for silent MSAL token acquisition (ssoSilent / acquireTokenSilent).-->
+<!--MSAL opens a hidden iframe pointing to this page; it monitors the iframe URL for the auth code in the hash.-->
+<!--The page must exist so that the browser navigates here successfully instead of falling back to the SPA shell.-->
+<html>
+  <head>
+    <title>Blank Auth End Page</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+  </body>
+</html>

--- a/todo-list-with-Azure-backend/tabs/public/blank-auth-end.html
+++ b/todo-list-with-Azure-backend/tabs/public/blank-auth-end.html
@@ -1,0 +1,11 @@
+<!--This file is used as the redirect URI for silent MSAL token acquisition (ssoSilent / acquireTokenSilent).-->
+<!--MSAL opens a hidden iframe pointing to this page; it monitors the iframe URL for the auth code in the hash.-->
+<!--The page must exist so that the browser navigates here successfully instead of falling back to the SPA shell.-->
+<html>
+  <head>
+    <title>Blank Auth End Page</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Fixes ADO Bug **36195045**: graph-toolkit-contact-exporter (and 10 other tab samples) crashes at runtime with an ArgumentNull error + 401 on Graph API calls when typing in the PeoplePicker search box.

## Root Cause

TeamsUserCredential.js/.ts calls msalInstance.ssoSilent() and cquireTokenSilent() with:

`js
redirectUri: \\/blank-auth-end.html\
`

This URL is also registered as a SPA redirect URI in ad.manifest.json. However, **lank-auth-end.html was never added to the public/ folder** of any affected sample.

CRA's webpack-dev-server falls back to serving index.html (the React SPA) when a static file is missing. When MSAL opens a hidden iframe navigating to /blank-auth-end.html, the browser loads the full React app instead. The React Router clears the URL hash containing the auth code → MSAL iframe monitoring fails → ssoSilent throws → getToken() returns "Failed to get access token cache silently" → TeamsFxProvider.getAccessToken() returns 
ull → Graph API calls go unauthenticated → **401** → **ArgumentNull** in GraphErrorHandler.

## Fix

Added a minimal lank-auth-end.html to the public/ (or 	abs/public/) folder of each affected sample. The page just needs to **exist** — MSAL only monitors the iframe URL; it does not depend on any scripts in the page.

`html
<html>
  <head>
    <title>Blank Auth End Page</title>
    <meta charset="utf-8" />
  </head>
  <body></body>
</html>
`

## Affected Samples (11)

| Sample | Path |
|--------|------|
| graph-toolkit-contact-exporter | public/ |
| graph-toolkit-one-productivity-hub | public/ |
| developer-assist-dashboard | public/ |
| copilot-connector-app | 	abs/public/ |
| intelligent-data-chart-generator | public/ |
| 	odo-list-with-Azure-backend-M365 | 	abs/public/ |
| 	odo-list-with-Azure-backend | 	abs/public/ |
| 	eam-central-dashboard | public/ |
| share-now | 	abs/public/ |
| hello-world-tab-with-backend | public/ |
| hello-world-tab-docker | public/ |

## Verification

1. Downloaded fresh sample via tk new sample graph-toolkit-contact-exporter
2. Provisioned (AAD app + Teams app) and started React dev server
3. **Before fix**: GET /blank-auth-end.html → served React SPA ("Microsoft Teams Tab") — confirms missing file
4. Applied fix (added lank-auth-end.html)
5. **After fix**: GET /blank-auth-end.html → served correct minimal MSAL handler page ("Blank Auth End Page")