### PR TITLE
fix: update da-ristorante-api directory path

### DIFF
--- a/.config/samples-config-v3.json
+++ b/.config/samples-config-v3.json
@@ -881,7 +881,7 @@
                 "owner": "pnp",
                 "repository": "copilot-pro-dev-samples",
                 "ref": "main",
-                "dir": "samples/da-ristorante-api"
+                "dir": "samples/da-ristorante-api-js"
             }
         },
         {


### PR DESCRIPTION
## Summary

The copilot-pro-dev-samples repo recently updated the directory path of \samples/da-ristorante-api/\.

This PR updates the \da-ristorante-api\ sample's \downloadUrlInfo.dir\ from:
- \samples/da-ristorante-api\ (old, now 404)

to:
- \samples/da-ristorante-api-js\ (new, valid)

## Verification

- Confirmed the old path returns 404: https://github.com/pnp/copilot-pro-dev-samples/tree/main/samples/da-ristorante-api
- Confirmed the new path is valid: https://github.com/pnp/copilot-pro-dev-samples/tree/main/samples/da-ristorante-api-js
