### PR TITLE
Add @qfai to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,6 @@
 # In each subsection folders are ordered first by depth, then alphabetically.
 # This should make it easy to add new rules without breaking existing ones.
 
-* @wh-alice @qinzhouxu @llhmm01 @tecton @sherylueen @Alive-Fish @HuihuiWu-Microsoft @yuqizhou77 @qinqingxu
+* @wh-alice @qinzhouxu @llhmm01 @tecton @sherylueen @Alive-Fish @HuihuiWu-Microsoft @yuqizhou77 @qinqingxu @qfai
 /.github/CODEOWNERS @wh-alice @zhenjiao-ms
 /.config/samples-config-v3.json @HuihuiWu-Microsoft @tecton @wh-alice


### PR DESCRIPTION
Add @qfai as a default code owner. Note: .idea/ is already present in the root .gitignore, so no change needed there.