### PR TITLE
fix: remove invalid link https://aka.ms/teamsfx-auth-code-flow

### DIFF
--- a/copilot-connector-app/tabs/src/components/sample/lib/TeamsUserCredential.ts
+++ b/copilot-connector-app/tabs/src/components/sample/lib/TeamsUserCredential.ts
@@ -111,10 +111,8 @@ export class TeamsUserCredential implements TokenCredential {
 
     // If code exists in result, user may using previous auth-start and auth-end page.
     if (resultJson.code) {
-      const helpLink = "https://aka.ms/teamsfx-auth-code-flow";
       const usingPreviousAuthPage =
-        "Found auth code in response. Auth code is not support for current version of SDK. " +
-        `Please refer to the help link for how to fix the issue: ${helpLink}.`;
+        "Found auth code in response. Auth code is not support for current version of SDK. ";
       console.error(usingPreviousAuthPage);
       throw new Error(usingPreviousAuthPage);
     }

--- a/developer-assist-dashboard/src/internal/TeamUserCredential.ts
+++ b/developer-assist-dashboard/src/internal/TeamUserCredential.ts
@@ -111,10 +111,8 @@ export class TeamsUserCredential implements TokenCredential {
 
     // If code exists in result, user may using previous auth-start and auth-end page.
     if (resultJson.code) {
-      const helpLink = "https://aka.ms/teamsfx-auth-code-flow";
       const usingPreviousAuthPage =
-        "Found auth code in response. Auth code is not support for current version of SDK. " +
-        `Please refer to the help link for how to fix the issue: ${helpLink}.`;
+        "Found auth code in response. Auth code is not support for current version of SDK. ";
       console.error(usingPreviousAuthPage);
       throw new Error(usingPreviousAuthPage);
     }

--- a/graph-toolkit-contact-exporter/src/components/Tab.js
+++ b/graph-toolkit-contact-exporter/src/components/Tab.js
@@ -75,11 +75,10 @@ class Tab extends React.Component {
       });
     } catch (err) {
       if (err.message?.includes("CancelledByUser")) {
-        const helpLink = "https://aka.ms/teamsfx-auth-code-flow";
         err.message +=
           '\nIf you see "AADSTS50011: The reply URL specified in the request does not match the reply URLs configured for the application" ' +
           "in the popup window, you may be using unmatched version for TeamsFx SDK (version >= 0.5.0) and Microsoft 365 Agents Toolkit (version < 3.3.0) or " +
-          `cli (version < 0.11.0). Please refer to the help link for how to fix the issue: ${helpLink}`;
+          "cli (version < 0.11.0).";
       }
 
       alert("Login failed: " + err);

--- a/graph-toolkit-contact-exporter/src/components/lib/TeamsUserCredential.js
+++ b/graph-toolkit-contact-exporter/src/components/lib/TeamsUserCredential.js
@@ -107,10 +107,8 @@ export class TeamsUserCredential {
 
     // If code exists in result, user may using previous auth-start and auth-end page.
     if (resultJson.code) {
-      const helpLink = "https://aka.ms/teamsfx-auth-code-flow";
       const usingPreviousAuthPage =
-        "Found auth code in response. Auth code is not support for current version of SDK. " +
-        `Please refer to the help link for how to fix the issue: ${helpLink}.`;
+        "Found auth code in response. Auth code is not support for current version of SDK. ";
       console.error(usingPreviousAuthPage);
       throw new Error(usingPreviousAuthPage);
     }

--- a/graph-toolkit-one-productivity-hub/src/components/Tab.jsx
+++ b/graph-toolkit-one-productivity-hub/src/components/Tab.jsx
@@ -110,11 +110,10 @@ class Tab extends React.Component {
       Providers.globalProvider.setState(ProviderState.SignedIn);
     } catch (err) {
       if (err.message?.includes("CancelledByUser")) {
-        const helpLink = "https://aka.ms/teamsfx-auth-code-flow";
         err.message +=
           '\nIf you see "AADSTS50011: The reply URL specified in the request does not match the reply URLs configured for the application" ' +
           "in the popup window, you may be using unmatched version for TeamsFx SDK (version >= 0.5.0) and Microsoft 365 Agents Toolkit (version < 3.3.0) or " +
-          `cli (version < 0.11.0). Please refer to the help link for how to fix the issue: ${helpLink}`;
+          "cli (version < 0.11.0).";
       }
       alert("Login failed: " + err);
       return;

--- a/graph-toolkit-one-productivity-hub/src/components/lib/TeamsUserCredential.js
+++ b/graph-toolkit-one-productivity-hub/src/components/lib/TeamsUserCredential.js
@@ -107,10 +107,8 @@ export class TeamsUserCredential {
 
     // If code exists in result, user may using previous auth-start and auth-end page.
     if (resultJson.code) {
-      const helpLink = "https://aka.ms/teamsfx-auth-code-flow";
       const usingPreviousAuthPage =
-        "Found auth code in response. Auth code is not support for current version of SDK. " +
-        `Please refer to the help link for how to fix the issue: ${helpLink}.`;
+        "Found auth code in response. Auth code is not support for current version of SDK. ";
       console.error(usingPreviousAuthPage);
       throw new Error(usingPreviousAuthPage);
     }

--- a/team-central-dashboard/src/internal/TeamsUserCredential.ts
+++ b/team-central-dashboard/src/internal/TeamsUserCredential.ts
@@ -112,10 +112,8 @@ export class TeamsUserCredential implements TokenCredential {
 
     // If code exists in result, user may using previous auth-start and auth-end page.
     if (resultJson.code) {
-      const helpLink = "https://aka.ms/teamsfx-auth-code-flow";
       const usingPreviousAuthPage =
-        "Found auth code in response. Auth code is not support for current version of SDK. " +
-        `Please refer to the help link for how to fix the issue: ${helpLink}.`;
+        "Found auth code in response. Auth code is not support for current version of SDK. ";
       console.error(usingPreviousAuthPage);
       throw new Error(usingPreviousAuthPage);
     }

--- a/todo-list-with-Azure-backend-M365/tabs/src/components/Tab.js
+++ b/todo-list-with-Azure-backend-M365/tabs/src/components/Tab.js
@@ -90,11 +90,10 @@ class Tab extends React.Component {
       await this.credential.login(this.scope);
     } catch (err) {
       if (err instanceof Error && err.message?.includes("CancelledByUser")) {
-        const helpLink = "https://aka.ms/teamsfx-auth-code-flow";
         err.message +=
           '\nIf you see "AADSTS50011: The reply URL specified in the request does not match the reply URLs configured for the application" ' +
           "in the popup window, you may be using unmatched version for TeamsFx SDK (version >= 0.5.0) and Microsoft 365 Agents Toolkit (version < 3.3.0) or " +
-          `cli (version < 0.11.0). Please refer to the help link for how to fix the issue: ${helpLink}`;
+          "cli (version < 0.11.0).";
       }
 
       alert("Login failed: " + err);


### PR DESCRIPTION
# Pull Request

## Description
This PR is to remove invalid link https://aka.ms/teamsfx-auth-code-flow.

The related ADO bug is https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/34380244/?view=edit.
<!-- Please provide a brief description of the changes in this PR -->

## Type of Change

- [ ] New sample onboarding (internal - source code in this repo)
- [ ] New sample onboarding (external - source code in another repo)
- [x] Sample update/fix
- [ ] Documentation update
- [ ] Validation tool update
- [ ] Other (please describe)

---

## For New Sample Onboarding

### Checklist

- [ ] I have added/updated the sample entry in `.config/samples-config-v3.json`
- [ ] I have included a README.md with setup instructions
- [ ] I have included a thumbnail image with correct aspect ratio (40:23, e.g., 1600×920 or 800×460)

### Validation Results (Required)

> **Important**: You must run the validation tool locally and provide a screenshot of the results.

#### For Internal Samples (source code in this repo)

```bash
cd validation-tool
npm install
node validator.mjs -p ../<your-sample-folder>
```

#### For External Samples (source code in another repo)

```bash
cd validation-tool
npm install

# Clone your sample repo (sparse checkout recommended)
git clone --filter=blob:none --sparse <your-repo-url>
cd <repo-name>
git sparse-checkout set <path-to-sample>
cd ..

# Run validation
node validate-external.js <sample-id> ./<repo-name>
```


---

## Related Issues

<!-- Link any related issues here, e.g., "Fixes #123" or "Related to #456" -->
if any question related to validation, may refer to the [Sample Validation Guide](validation-tool/sample_validation.md)
if still has questions, may open a issue :)
