### PR TITLE
Fix ProxyAgent-NodeJS image extension to png

### DIFF
--- a/.config/samples-config-v3.json
+++ b/.config/samples-config-v3.json
@@ -882,8 +882,8 @@
       ],
       "time": "5 mins to run",
       "configuration": "Manual configurations required",
-      "thumbnailPath": "images/screen009.jpg",
-      "gifPath": "images/screen009.jpg",
+      "thumbnailPath": "images/screen009.png",
+      "gifPath": "images/screen009.png",
       "suggested": true
     },
     {


### PR DESCRIPTION
Updates `thumbnailPath` and `gifPath` for the `ProxyAgent-NodeJS` entry in `.config/samples-config-v3.json` from `images/screen009.jpg` to `images/screen009.png`.