### PR TITLE
Quality: Missing directory existence check causes unhandled crash in build hook

### DIFF
--- a/data-analyst-agent-v2/tsup.config.js
+++ b/data-analyst-agent-v2/tsup.config.js
@@ -18,7 +18,7 @@ module.exports = {
     const srcDataDir = join(__dirname, 'src', 'data');
     const distDataDir = join(__dirname, 'dist', 'data');
     
-mkdirSync(distDataDir, { recursive: true });
+    mkdirSync(distDataDir, { recursive: true });
 
     if (!existsSync(srcDataDir)) {
       console.warn('src/data directory not found, skipping static file copy');

--- a/data-analyst-agent-v2/tsup.config.js
+++ b/data-analyst-agent-v2/tsup.config.js
@@ -1,4 +1,4 @@
-const { copyFileSync, mkdirSync, readdirSync } = require('fs');
+const { copyFileSync, mkdirSync, readdirSync, existsSync } = require('fs');
 const { join } = require('path');
 
 /** @type {import('tsup').Options} */
@@ -18,8 +18,13 @@ module.exports = {
     const srcDataDir = join(__dirname, 'src', 'data');
     const distDataDir = join(__dirname, 'dist', 'data');
     
-    mkdirSync(distDataDir, { recursive: true });
-    
+mkdirSync(distDataDir, { recursive: true });
+
+    if (!existsSync(srcDataDir)) {
+      console.warn('src/data directory not found, skipping static file copy');
+      return;
+    }
+
     const files = readdirSync(srcDataDir);
     for (const file of files) {
       if (file.endsWith('.sql') || file.endsWith('.jsonl') || file.endsWith('.md') || file.endsWith('.db')) {


### PR DESCRIPTION
## ✨ Code Quality

### Problem
The `onSuccess` handler calls `readdirSync(srcDataDir)` without verifying the `src/data` directory exists. If a developer deletes or restructures the directory, or if a fresh clone is missing it, the build will crash with an unhandled `ENOENT` error. This is a build-breaking bug that surfaces as an opaque Node.js filesystem error rather than a clear message.


**Severity**: `high`
**File**: `data-analyst-agent-v2/tsup.config.js`

### Solution
const srcDataDir = join(__dirname, 'src', 'data');
const distDataDir = join(__dirname, 'dist', 'data');

mkdirSync(distDataDir, { recursive: true });

if (!existsSync(srcDataDir)) {
  console.warn('src/data directory not found, skipping static file copy');
  return;
}

const files = readdirSync(srcDataDir);


### Changes
- `data-analyst-agent-v2/tsup.config.js` (modified)

# Pull Request

## Description



## Type of Change

- [ ] New sample onboarding (internal - source code in this repo)
- [ ] New sample onboarding (external - source code in another repo)
- [ ] Sample update/fix
- [ ] Documentation update
- [ ] Validation tool update
- [ ] Other (please describe)

---

## For New Sample Onboarding

### Checklist

- [ ] I have added/updated the sample entry in `.config/samples-config-v3.json`
- [ ] I have included a README.md with setup instructions
- [ ] I have included a thumbnail image with correct aspect ratio (40:23, e.g., 1600×920 or 800×460)

### Validation Results (Required)

> **Important**: You must run the validation tool locally and provide a screenshot of the results.

#### For Internal Samples (source code in this repo)

```bash
cd validation-tool
npm install
node validator.mjs -p ../<your-sample-folder>
```

#### For External Samples (source code in another repo)

```bash
cd validation-tool
npm install

# Clone your sample repo (sparse checkout recommended)
git clone --filter=blob:none --sparse <your-repo-url>
cd <repo-name>
git sparse-checkout set <path-to-sample>
cd ..

# Run validation
node validate-external.js <sample-id> ./<repo-name>
```


---

## Related Issues


if any question related to validation, may refer to the [Sample Validation Guide](validation-tool/sample_validation.md)
if still has questions, may open a issue :)

---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #1754