### PR TITLE
chore: remove spfx sample from config

### DIFF
--- a/.config/samples-config-v3.json
+++ b/.config/samples-config-v3.json
@@ -19,7 +19,6 @@
       "Azure",
       "Adaptive Cards",
       "SSO",
-      "SPFx",
       "Outlook",
       "Graph",
       "Dev Proxy"
@@ -186,27 +185,6 @@
       ],
       "time": "5min to run",
       "configuration": "Ready for debug",
-      "thumbnailPath": "assets/thumbnail.png",
-      "gifPath": "assets/sampleDemo.gif",
-      "suggested": false
-    },
-    {
-      "id": "todo-list-SPFx",
-      "shortId": "todo-spfx",
-      "onboardDate": "2021-05-06",
-      "title": "Todo List with SPFx",
-      "shortDescription": "Todo List app hosting on SharePoint",
-      "fullDescription": "The \"Todo List with SPFx\" is a Microsoft Teams application that provides a collaborative task management tool for Teams or Channel members. The application is hosted on SharePoint, allowing users to create, update, and delete tasks within a shared Todo List. The main user scenario involves members of a Team or Channel collaborating on the same Todo List and manipulating the same set of Todo items. The application leverages SharePoint Framework (SPFx) for its development and uses Single Sign-On (SSO) for user authentication. It also utilizes the Microsoft Graph Toolkit for accessing and manipulating Microsoft Graph data. The application does not require an Azure account for deployment, instead, it is deployed to the SharePoint App Catalog and synced to the Teams App Catalog. The application is primarily a Tab application and is written in TypeScript.",
-      "types": [
-        "Tab"
-      ],
-      "tags": [
-        "SharePoint",
-        "SPFx",
-        "TS"
-      ],
-      "time": "1hr to run",
-      "configuration": "Manual configurations required",
       "thumbnailPath": "assets/thumbnail.png",
       "gifPath": "assets/sampleDemo.gif",
       "suggested": false


### PR DESCRIPTION
# Pull Request

## Description

https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/38927442

https://github.com/OfficeDev/microsoft-365-agents-toolkit-test/issues/15929

## Type of Change

- [ ] New sample onboarding (internal - source code in this repo)
- [ ] New sample onboarding (external - source code in another repo)
- [ ] Sample update/fix
- [ ] Documentation update
- [ ] Validation tool update
- [ ] Other (please describe)

---

## For New Sample Onboarding

### Checklist

- [ ] I have added/updated the sample entry in `.config/samples-config-v3.json`
- [ ] I have included a README.md with setup instructions
- [ ] I have included a thumbnail image with correct aspect ratio (40:23, e.g., 1600×920 or 800×460)

### Validation Results (Required)

> **Important**: You must run the validation tool locally and provide a screenshot of the results.

#### For Internal Samples (source code in this repo)

```bash
cd validation-tool
npm install
node validator.mjs -p ../<your-sample-folder>
```

#### For External Samples (source code in another repo)

```bash
cd validation-tool
npm install

# Clone your sample repo (sparse checkout recommended)
git clone --filter=blob:none --sparse <your-repo-url>
cd <repo-name>
git sparse-checkout set <path-to-sample>
cd ..

# Run validation
node validate-external.js <sample-id> ./<repo-name>
```


---

## Related Issues

<!-- Link any related issues here, e.g., "Fixes #123" or "Related to #456" -->
if any question related to validation, may refer to the [Sample Validation Guide](validation-tool/sample_validation.md)
if still has questions, may open a issue :)
